### PR TITLE
disable cage and jar mob capturing

### DIFF
--- a/config/supplementaries-common.json
+++ b/config/supplementaries-common.json
@@ -70,12 +70,12 @@
       "drink_from_jar": true,
       "drink_from_jar_item": false,
       "jar_auto_detect": false,
-      "jar_capture": true,
+      "jar_capture": false,
       "jar_cookies": true,
       "jar_liquids": true
     },
     "cage": {
-      "enabled": true,
+      "enabled": false,
       "allow_all_mobs": true,
       "cage_allow_all_babies": true,
       "cage_auto_detect": false,


### PR DESCRIPTION
[This client crash](https://github.com/ChloeTax/hexxytest3/issues/95) arises when opening the inventory while holding a cage with a mob in it and opening the inventory, as it was on the last server (more info in the discussion at the link). this crash also extends to jars that hold mobs, but only the mob capture feature of jars needs to be disabled for this. not sure if a replacement mob capture mod is needed here