### PR TITLE
unbind quiver (fixes #133)

### DIFF
--- a/config/default-hotkeys.json
+++ b/config/default-hotkeys.json
@@ -497,7 +497,7 @@
   {
     "comment": "supplementaries.keybind.quiver",
     "translation": "Quiver",
-    "key": "key.keyboard.v"
+    "key": "key.keyboard.unknown"
   },
   {
     "comment": "tcdcommons.key.refresh_current_screen",


### PR DESCRIPTION
fixes #133 

note: the conflict between "Open Notes" and "Open Hex Notebook" need not be resolved; as the latter only functions when in the hex grid, both can be used without issue. I've been using both comfortably from the start myself