### PR TITLE
Blacklist certain Iotas in the Everbook

### DIFF
--- a/kubejs/server_scripts/BlacklistEverbook.js
+++ b/kubejs/server_scripts/BlacklistEverbook.js
@@ -1,0 +1,8 @@
+ServerEvents.tags('iota_type', event => {
+  event.add('hexal:illegal_interworld', 'complexhex:bubbleiota')
+  event.add('hexal:illegal_interworld', 'hexcellular:property')
+  event.add('hexal:illegal_interworld', 'oneironaut:uuid')
+  event.add('hexal:illegal_interworld', 'ephemera:potion')
+  event.add('hexal:illegal_interworld', 'oneironaut:dim')
+})
+console.info("Iotas Blacklisted - Everbook")


### PR DESCRIPTION
Blacklist Iotas in Everbook. The bubble iota doesn't seem to work. Perhaps consult with Kinetic?