### PR TITLE
add FSB plugin that makes Carpet bots work

### DIFF
--- a/mods/fsb-carpet-addon.pw.toml
+++ b/mods/fsb-carpet-addon.pw.toml
@@ -1,15 +1,15 @@
 name = "fsb-carpet-addon"
-filename = "fsb-carpet-addon-0.1.0.jar"
+filename = "fsb-carpet-addon-0.1.1.jar"
 side = "server"
 
 [download]
-url = "https://github.com/penguinencounter/fsb-carpet-addon/releases/download/v0.1.0/fsb-carpet-addon-0.1.0.jar"
+url = "https://github.com/penguinencounter/fsb-carpet-addon/releases/download/v0.1.1/fsb-carpet-addon-0.1.1.jar"
 hash-format = "sha256"
-hash = "736fe6fc5c6ebbb1915cc03a55d2a4f73a7abe512b12c9ff60803e38600a8838"
+hash = "6e6fbf2069ec9be848228ac5de0c276874720ec9c4e72e93b1152d52eb2ba9d9"
 
 [update]
 [update.github]
 branch = "main"
 regex = "^.+(?<!-api|-dev|-dev-preshadow|-sources)\\.jar$"
 slug = "penguinencounter/fsb-carpet-addon"
-tag = "v0.1.0"
+tag = "v0.1.1"


### PR DESCRIPTION
so this _should_ work for making Carpet bots without changing the Figura version.
(our patch for the client end of it got turned down so instead server addon it is)
[fsb-carpet-addon](https://github.com/penguinencounter/fsb-carpet-addon) (the source code is just 1 kotlin file)

You might have to reload (hold R, select reload from menu) the players the first time after you set the avatars but other than that they work just fine

(tested with the version of Figura currently in the hexxytest pack:)
![two carpet bots and one real player](https://github.com/user-attachments/assets/59bd9d4e-5a11-44bc-b9ac-ac6b2fde5c74)

